### PR TITLE
5.8+ HasOneThrough relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,32 @@ Quickly get your models up and running with Laravel Model Snippets. Start with `
 ## Features
 ![Example](images/example.gif)
 
-| Snippet                      | Purpose                       |
-| ---------------------------- | ----------------------------- |
-| `Model::t`                   | Table                         |
-| `Model::pk`                  | Primary Key                   |
-| `Model::ts`                  | Timestamps                    |
-| `Model::df`                  | Date Format                   |
-| `Model::con`                 | Database Connection           |
-| `Model::c`                   | Casts Attributes              |
-| `Model::f`                   | Mass Assignment (Fillable)    |
-| `Model::g`                   | Guard Attributes              |
-| `Model::d`                   | Dates                         |
-| `Model::b`                   | Boot                          |
-| `Model::s`                   | Local Scope                   |
-| `Model::oo`                  | One to One Relationship       |
-| `Model::bt`                  | Belongs To Relationship       |
-| `Model::om`                  | One to Many Relationship      |
-| `Model::mm`                  | Many to Many Relationship     |
-| `Model::btm`                 | Belongs To Many Relationship  |
-| `Model::hmt`                 | Has Many Through Relationship |
-| `Model::h`                   | Hidden Attributes             |
-| `Model::v`                   | Visible Attributes            |
-| `Model::a`                   | Appends                       |
-| `Modal::tc`                  | Relationship Touches          |
-| `Model::i`                   | Incrementing                  |
-| `Modal::pp`                  | Per Page Pagination           |
+| Snippet                      | Purpose                            |
+| ---------------------------- | ---------------------------------- |
+| `Model::t`                   | Table                              |
+| `Model::pk`                  | Primary Key                        |
+| `Model::ts`                  | Timestamps                         |
+| `Model::df`                  | Date Format                        |
+| `Model::con`                 | Database Connection                |
+| `Model::c`                   | Casts Attributes                   |
+| `Model::f`                   | Mass Assignment (Fillable)         |
+| `Model::g`                   | Guard Attributes                   |
+| `Model::d`                   | Dates                              |
+| `Model::b`                   | Boot                               |
+| `Model::s`                   | Local Scope                        |
+| `Model::oo`                  | One to One Relationship            |
+| `Model::bt`                  | Belongs To Relationship            |
+| `Model::om`                  | One to Many Relationship           |
+| `Model::mm`                  | Many to Many Relationship          |
+| `Model::btm`                 | Belongs To Many Relationship       |
+| `Model::hmt`                 | Has Many Through Relationship      |
+| `Model::hot`                 | Has One Through Relationship (5.8) |
+| `Model::h`                   | Hidden Attributes                  |
+| `Model::v`                   | Visible Attributes                 |
+| `Model::a`                   | Appends                            |
+| `Modal::tc`                  | Relationship Touches               |
+| `Model::i`                   | Incrementing                       |
+| `Modal::pp`                  | Per Page Pagination                |
 
 
 ## Changelog

--- a/snippets/model.json
+++ b/snippets/model.json
@@ -212,7 +212,7 @@
 			" */",
 			"public function $1()",
 			"{",
-			"\treturn \\$this->hasOneThrough($2::class, $3::class);",
+			"\treturn \\$this->hasOneThrough('App\\\\$2', 'App\\\\$3');",
 			"}"
 		],
 		"description": "Has One Through: Define a Has One Through relationship within your model. (5.8+)"

--- a/snippets/model.json
+++ b/snippets/model.json
@@ -202,6 +202,21 @@
 		],
 		"description": "Has Many Through: Define a Has Many Through relationship within your model."
 	},
+	"Laravel Model: Has One Through": {
+		"prefix": "Model::hot",
+		"body": [
+			"/**",
+			" * // Relationship description",
+			" * ",
+			" * @return \\Illuminate\\Database\\Eloquent\\Relations\\HasOneThrough",
+			" */",
+			"public function $1()",
+			"{",
+			"\treturn \\$this->hasOneThrough($2::class, $3::class);",
+			"}"
+		],
+		"description": "Has One Through: Define a Has One Through relationship within your model. (5.8+)"
+	},
 	"Laravel Model: Hidden": {
 		"prefix": "Model::h",
 		"body": [


### PR DESCRIPTION
This will add the HasOneThrough relationship available in Laravel 5.8+

I've added some default docBlock for this one as well. This is what I usually do with relationships, but I can understand it if you would choose to remove it. 

https://laravel.com/docs/5.8/eloquent-relationships#has-one-through