### PR TITLE
`$incrementing` access level needs to be `public`

### DIFF
--- a/snippets/model.json
+++ b/snippets/model.json
@@ -268,7 +268,7 @@
 			" *",
 			" * @var bool",
 			" */",
-			"protected \\$incrementing = ${1:false};"
+			"public \\$incrementing = ${1:false};"
 		],
 		"description": "Incrementing: Indicates if the IDs are auto-incrementing."
 	},


### PR DESCRIPTION
This through an error for me. The access level should be the same as in the parent class:   https://github.com/laravel/framework/blob/0e0a428a50fc8378e3f77d18f3caae76c19e8c7a/src/Illuminate/Database/Eloquent/Model.php#L64