### PR TITLE
change keyType snippet

### DIFF
--- a/snippets/model.json
+++ b/snippets/model.json
@@ -280,7 +280,7 @@
 			" *",
 			" * @var string",
 			" */",
-			"protected \\$keyType = ${1:'int'};"
+			"protected \\$keyType = '${1:int}';"
 		],
 		"description": "KeyType: The \"type\" of the auto-incrementing ID."
 	},


### PR DESCRIPTION
moves cursor selection point $1 inside the quotation marks instead of around it, which is in line with other snippets and generally more convenient.